### PR TITLE
Dev "Cut over to nmte.org custom domain"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+nmte.org

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: New Musical Theatre Exchange
 description: "Bringing together committed musical theatre writers in the Twin Cities and surrounding region"
-url: "https://charlestbetz.github.io"
-baseurl: "/nmte.org"
+url: "https://nmte.org"
+baseurl: ""
 
 theme: minima
 


### PR DESCRIPTION
Why: "DNS migration from Wix to Cloudflare + GitHub Pages custom domain. Updates url, sets baseurl: "" to remove path prefix, adds CNAME file pointing GitHub Pages at nmte.org."
Verification: "Reviewed at dev.nmte-site.pages.dev — site renders correctly. Cloudflare DNS edits and GitHub Pages SSL provisioning to follow after merge."
Notes/followups: "Once stable, can also remove the --baseurl "" override from Cloudflare Pages build command — it's redundant now but harmless."

